### PR TITLE
feat: add interactive BUILD zone with MCP diagram, throughput viz, terminal demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@xyflow/react": "^12.10.1",
     "framer-motion": "^12.38.0",
     "geist": "^1.7.0",
     "next": "16.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@xyflow/react':
+        specifier: ^12.10.1
+        version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -508,6 +511,24 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -682,6 +703,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@xyflow/react@12.10.1':
+    resolution: {integrity: sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.75':
+    resolution: {integrity: sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -808,6 +838,9 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -830,6 +863,44 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -1909,6 +1980,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -1949,6 +2025,21 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -2374,6 +2465,27 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2542,6 +2654,29 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@xyflow/react@12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@xyflow/system': 0.0.75
+      classcat: 5.0.5
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.75':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2695,6 +2830,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  classcat@5.0.5: {}
+
   client-only@0.0.1: {}
 
   color-convert@2.0.1:
@@ -2714,6 +2851,42 @@ snapshots:
       which: 2.0.2
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   damerau-levenshtein@1.0.8: {}
 
@@ -4030,6 +4203,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -4086,3 +4263,10 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4

--- a/src/components/build/build-zone.tsx
+++ b/src/components/build/build-zone.tsx
@@ -1,4 +1,40 @@
+"use client";
+
+import dynamic from "next/dynamic";
 import { buildCards } from "@/lib/content";
+import { ProjectCard } from "./project-card";
+
+const MCPDiagram = dynamic(
+  () => import("./mcp-diagram").then((m) => ({ default: m.MCPDiagram })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[380px] animate-pulse rounded-lg bg-white/[0.04]" />
+    ),
+  },
+);
+
+const ThroughputViz = dynamic(
+  () =>
+    import("./throughput-viz").then((m) => ({ default: m.ThroughputViz })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[300px] animate-pulse rounded-lg bg-white/[0.04]" />
+    ),
+  },
+);
+
+const TerminalDemo = dynamic(
+  () =>
+    import("./terminal-demo").then((m) => ({ default: m.TerminalDemo })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[300px] animate-pulse rounded-lg bg-white/[0.04]" />
+    ),
+  },
+);
 
 export function BuildZone() {
   return (
@@ -11,37 +47,38 @@ export function BuildZone() {
           Systems that scale, tools that simplify
         </p>
 
-        <div className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {buildCards.map((card) => (
-            <article
-              key={card.title}
-              className="group rounded-xl border border-white/[0.08] p-6 transition-colors duration-300 hover:border-white/[0.16] hover:bg-white/[0.02]"
+        <div className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2">
+          {/* MCP Diagram — full width on first row */}
+          <div className="md:col-span-2">
+            <ProjectCard
+              title={buildCards[0].title}
+              description={buildCards[0].description}
+              metric={buildCards[0].metric}
+              stack={buildCards[0].stack}
             >
-              <h3 className="text-lg font-medium tracking-tight">
-                {card.title}
-              </h3>
-              <p className="mt-3 text-sm leading-relaxed text-[var(--color-muted)]">
-                {card.description}
-              </p>
+              <MCPDiagram />
+            </ProjectCard>
+          </div>
 
-              <div className="mt-4 inline-flex items-center rounded-full border border-[var(--color-accent)]/20 bg-[var(--color-accent)]/10 px-3 py-1">
-                <span className="font-mono text-xs text-[var(--color-accent)]">
-                  {card.metric}
-                </span>
-              </div>
+          {/* Throughput viz */}
+          <ProjectCard
+            title={buildCards[1].title}
+            description={buildCards[1].description}
+            metric={buildCards[1].metric}
+            stack={buildCards[1].stack}
+          >
+            <ThroughputViz />
+          </ProjectCard>
 
-              <div className="mt-4 flex flex-wrap gap-2">
-                {card.stack.map((tech) => (
-                  <span
-                    key={tech}
-                    className="rounded-md bg-white/[0.06] px-2 py-0.5 font-mono text-xs text-[var(--color-muted)]"
-                  >
-                    {tech}
-                  </span>
-                ))}
-              </div>
-            </article>
-          ))}
+          {/* Terminal demo */}
+          <ProjectCard
+            title={buildCards[2].title}
+            description={buildCards[2].description}
+            metric={buildCards[2].metric}
+            stack={buildCards[2].stack}
+          >
+            <TerminalDemo />
+          </ProjectCard>
         </div>
       </div>
     </section>

--- a/src/components/build/mcp-diagram.tsx
+++ b/src/components/build/mcp-diagram.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  ReactFlow,
+  type Node,
+  type Edge,
+  type NodeProps,
+  Handle,
+  Position,
+} from "@xyflow/react";
+import "@xyflow/react/dist/base.css";
+
+const NODE_DESCRIPTIONS: Record<string, string> = {
+  openwebui: "Chat interface for non-technical users to interact with Claude",
+  electron: "Desktop app with custom workflows and document processing",
+  litellm: "API gateway running on ECS, routing requests across LLM providers",
+  claude: "Anthropic Claude via AWS Bedrock for enterprise-grade AI",
+  jira: "MCP server for project tracking and ticket management",
+  confluence: "MCP server for knowledge base and documentation access",
+  gitlab: "MCP server for code repository and CI/CD integration",
+  sonarqube: "MCP server for code quality and security analysis",
+  sonatype: "MCP server for dependency vulnerability scanning",
+  slack: "MCP server for team notifications and workflow triggers",
+};
+
+function DiagramNode({ data }: NodeProps) {
+  const [hovered, setHovered] = useState(false);
+  const nodeData = data as { label: string; nodeId: string; variant: string };
+  const isMcp = nodeData.variant === "mcp";
+  const isGateway = nodeData.variant === "gateway";
+
+  return (
+    <div
+      className="relative"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div
+        className={`
+          rounded-lg border px-3 py-2 font-mono text-xs transition-all duration-200
+          ${isGateway
+            ? "border-[var(--color-accent)]/40 bg-[var(--color-accent)]/10 text-[var(--color-accent)] shadow-[0_0_12px_rgba(245,158,11,0.15)]"
+            : isMcp
+              ? "border-white/[0.12] bg-white/[0.04] text-[var(--color-muted)] hover:border-white/[0.2] hover:bg-white/[0.06]"
+              : "border-white/[0.12] bg-white/[0.06] text-[var(--color-foreground)] hover:border-white/[0.2]"
+          }
+        `}
+      >
+        {nodeData.label}
+      </div>
+
+      {hovered && NODE_DESCRIPTIONS[nodeData.nodeId] && (
+        <div className="absolute -top-10 left-1/2 z-50 -translate-x-1/2 whitespace-nowrap rounded-md bg-[#1a1a1a] px-3 py-1.5 text-xs text-[var(--color-foreground)] shadow-lg ring-1 ring-white/[0.12]">
+          {NODE_DESCRIPTIONS[nodeData.nodeId]}
+          <div className="absolute -bottom-1 left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 bg-[#1a1a1a] ring-1 ring-white/[0.12]" />
+        </div>
+      )}
+
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!h-1.5 !w-1.5 !border-0 !bg-white/20"
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!h-1.5 !w-1.5 !border-0 !bg-white/20"
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="bottom"
+        className="!h-1.5 !w-1.5 !border-0 !bg-white/20"
+      />
+      <Handle
+        type="target"
+        position={Position.Top}
+        id="top"
+        className="!h-1.5 !w-1.5 !border-0 !bg-white/20"
+      />
+    </div>
+  );
+}
+
+const nodeTypes = { diagram: DiagramNode };
+
+const NODES: Node[] = [
+  {
+    id: "openwebui",
+    type: "diagram",
+    position: { x: 0, y: 40 },
+    data: { label: "Open WebUI", nodeId: "openwebui", variant: "client" },
+  },
+  {
+    id: "electron",
+    type: "diagram",
+    position: { x: 0, y: 120 },
+    data: { label: "Electron App", nodeId: "electron", variant: "client" },
+  },
+  {
+    id: "litellm",
+    type: "diagram",
+    position: { x: 220, y: 80 },
+    data: { label: "LiteLLM (ECS)", nodeId: "litellm", variant: "gateway" },
+  },
+  {
+    id: "claude",
+    type: "diagram",
+    position: { x: 440, y: 80 },
+    data: { label: "Claude / Bedrock", nodeId: "claude", variant: "client" },
+  },
+  {
+    id: "jira",
+    type: "diagram",
+    position: { x: 100, y: 220 },
+    data: { label: "Jira", nodeId: "jira", variant: "mcp" },
+  },
+  {
+    id: "confluence",
+    type: "diagram",
+    position: { x: 200, y: 220 },
+    data: { label: "Confluence", nodeId: "confluence", variant: "mcp" },
+  },
+  {
+    id: "gitlab",
+    type: "diagram",
+    position: { x: 300, y: 220 },
+    data: { label: "GitLab", nodeId: "gitlab", variant: "mcp" },
+  },
+  {
+    id: "sonarqube",
+    type: "diagram",
+    position: { x: 100, y: 280 },
+    data: { label: "SonarQube", nodeId: "sonarqube", variant: "mcp" },
+  },
+  {
+    id: "sonatype",
+    type: "diagram",
+    position: { x: 210, y: 280 },
+    data: { label: "Sonatype", nodeId: "sonatype", variant: "mcp" },
+  },
+  {
+    id: "slack",
+    type: "diagram",
+    position: { x: 320, y: 280 },
+    data: { label: "Slack", nodeId: "slack", variant: "mcp" },
+  },
+];
+
+const EDGES: Edge[] = [
+  {
+    id: "e-webui-litellm",
+    source: "openwebui",
+    target: "litellm",
+    animated: true,
+    style: { stroke: "rgba(245, 158, 11, 0.3)", strokeWidth: 1.5 },
+  },
+  {
+    id: "e-electron-litellm",
+    source: "electron",
+    target: "litellm",
+    animated: true,
+    style: { stroke: "rgba(245, 158, 11, 0.3)", strokeWidth: 1.5 },
+  },
+  {
+    id: "e-litellm-claude",
+    source: "litellm",
+    target: "claude",
+    animated: true,
+    style: { stroke: "rgba(245, 158, 11, 0.5)", strokeWidth: 2 },
+  },
+  {
+    id: "e-litellm-jira",
+    source: "litellm",
+    sourceHandle: "bottom",
+    target: "jira",
+    targetHandle: "top",
+    animated: true,
+    style: { stroke: "rgba(255, 255, 255, 0.12)", strokeWidth: 1 },
+  },
+  {
+    id: "e-litellm-confluence",
+    source: "litellm",
+    sourceHandle: "bottom",
+    target: "confluence",
+    targetHandle: "top",
+    animated: true,
+    style: { stroke: "rgba(255, 255, 255, 0.12)", strokeWidth: 1 },
+  },
+  {
+    id: "e-litellm-gitlab",
+    source: "litellm",
+    sourceHandle: "bottom",
+    target: "gitlab",
+    targetHandle: "top",
+    animated: true,
+    style: { stroke: "rgba(255, 255, 255, 0.12)", strokeWidth: 1 },
+  },
+  {
+    id: "e-litellm-sonarqube",
+    source: "litellm",
+    sourceHandle: "bottom",
+    target: "sonarqube",
+    targetHandle: "top",
+    animated: true,
+    style: { stroke: "rgba(255, 255, 255, 0.12)", strokeWidth: 1 },
+  },
+  {
+    id: "e-litellm-sonatype",
+    source: "litellm",
+    sourceHandle: "bottom",
+    target: "sonatype",
+    targetHandle: "top",
+    animated: true,
+    style: { stroke: "rgba(255, 255, 255, 0.12)", strokeWidth: 1 },
+  },
+  {
+    id: "e-litellm-slack",
+    source: "litellm",
+    sourceHandle: "bottom",
+    target: "slack",
+    targetHandle: "top",
+    animated: true,
+    style: { stroke: "rgba(255, 255, 255, 0.12)", strokeWidth: 1 },
+  },
+];
+
+export function MCPDiagram() {
+  const onInit = useCallback((instance: { fitView: () => void }) => {
+    instance.fitView();
+  }, []);
+
+  return (
+    <div className="h-[380px] w-full" style={{ background: "transparent" }}>
+      <ReactFlow
+        nodes={NODES}
+        edges={EDGES}
+        nodeTypes={nodeTypes}
+        onInit={onInit}
+        fitView
+        panOnDrag={false}
+        zoomOnScroll={false}
+        zoomOnPinch={false}
+        zoomOnDoubleClick={false}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        proOptions={{ hideAttribution: true }}
+        style={{ background: "transparent" }}
+      />
+    </div>
+  );
+}

--- a/src/components/build/project-card.tsx
+++ b/src/components/build/project-card.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { motion } from "framer-motion";
+
+interface ProjectCardProps {
+  title: string;
+  description: string;
+  metric: string;
+  stack: string[];
+  children: ReactNode;
+}
+
+export function ProjectCard({
+  title,
+  description,
+  metric,
+  stack,
+  children,
+}: ProjectCardProps) {
+  return (
+    <motion.article
+      className="group relative overflow-hidden rounded-xl border border-white/[0.08] transition-colors duration-300 hover:border-white/[0.16]"
+      whileHover={{ scale: 1.005 }}
+      transition={{ type: "spring", stiffness: 400, damping: 30 }}
+    >
+      <div className="pointer-events-none absolute inset-0 rounded-xl opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+        style={{
+          background:
+            "radial-gradient(600px circle at var(--mouse-x, 50%) var(--mouse-y, 50%), rgba(245, 158, 11, 0.04), transparent 40%)",
+        }}
+      />
+
+      <div className="relative">{children}</div>
+
+      <div className="relative px-6 pb-6 pt-4">
+        <h3 className="text-lg font-medium tracking-tight">{title}</h3>
+        <p className="mt-2 text-sm leading-relaxed text-[var(--color-muted)]">
+          {description}
+        </p>
+
+        <div className="mt-4 inline-flex items-center rounded-full border border-[var(--color-accent)]/20 bg-[var(--color-accent)]/10 px-3 py-1">
+          <span className="font-mono text-xs text-[var(--color-accent)]">
+            {metric}
+          </span>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-2">
+          {stack.map((tech) => (
+            <span
+              key={tech}
+              className="rounded-md bg-white/[0.06] px-2 py-0.5 font-mono text-xs text-[var(--color-muted)]"
+            >
+              {tech}
+            </span>
+          ))}
+        </div>
+      </div>
+    </motion.article>
+  );
+}

--- a/src/components/build/terminal-demo.tsx
+++ b/src/components/build/terminal-demo.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const COMMAND = "$ onboard --environment staging --team platform";
+const CHAR_DELAY = 40;
+const LINE_DELAY = 200;
+const PAUSE_AFTER_COMMAND = 500;
+const PAUSE_BEFORE_REPLAY = 3000;
+
+const OUTPUT_LINES = [
+  { text: "\u2713 Provisioning cloud resources...", delay: LINE_DELAY },
+  { text: "\u2713 Configuring access policies...", delay: LINE_DELAY },
+  { text: "\u2713 Installing 12 plugins...", delay: LINE_DELAY },
+  { text: "\u2713 Running validation suite...", delay: LINE_DELAY },
+  { text: "\u2713 Environment ready in 47 minutes", delay: LINE_DELAY },
+];
+
+type Phase = "idle" | "typing" | "output" | "done";
+
+export function TerminalDemo() {
+  const [typedCommand, setTypedCommand] = useState("");
+  const [visibleLines, setVisibleLines] = useState<string[]>([]);
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [showReplay, setShowReplay] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isRunningRef = useRef(false);
+
+  const cleanup = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    cleanup();
+    setTypedCommand("");
+    setVisibleLines([]);
+    setPhase("idle");
+    setShowReplay(false);
+    isRunningRef.current = false;
+  }, [cleanup]);
+
+  const runSequence = useCallback(() => {
+    if (isRunningRef.current) return;
+    isRunningRef.current = true;
+    setPhase("typing");
+    setShowReplay(false);
+
+    let charIndex = 0;
+
+    function typeNextChar() {
+      if (charIndex < COMMAND.length) {
+        charIndex++;
+        setTypedCommand(COMMAND.slice(0, charIndex));
+        timerRef.current = setTimeout(typeNextChar, CHAR_DELAY);
+      } else {
+        timerRef.current = setTimeout(showNextLine, PAUSE_AFTER_COMMAND);
+      }
+    }
+
+    let lineIndex = 0;
+
+    function showNextLine() {
+      setPhase("output");
+      if (lineIndex < OUTPUT_LINES.length) {
+        setVisibleLines((prev) => [...prev, OUTPUT_LINES[lineIndex].text]);
+        lineIndex++;
+        timerRef.current = setTimeout(
+          showNextLine,
+          OUTPUT_LINES[lineIndex - 1].delay,
+        );
+      } else {
+        setPhase("done");
+        setShowReplay(true);
+        timerRef.current = setTimeout(() => {
+          isRunningRef.current = false;
+        }, PAUSE_BEFORE_REPLAY);
+      }
+    }
+
+    typeNextChar();
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !isRunningRef.current) {
+          reset();
+          timerRef.current = setTimeout(runSequence, 300);
+        }
+        if (!entry.isIntersecting && phase === "done") {
+          reset();
+        }
+      },
+      { threshold: 0.4 },
+    );
+
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      cleanup();
+    };
+  }, [phase, reset, runSequence, cleanup]);
+
+  return (
+    <div ref={containerRef} className="overflow-hidden rounded-lg">
+      {/* Window chrome */}
+      <div className="flex items-center gap-2 bg-[#1a1a1a] px-4 py-2.5">
+        <span className="h-3 w-3 rounded-full bg-[#ff5f57]" />
+        <span className="h-3 w-3 rounded-full bg-[#febc2e]" />
+        <span className="h-3 w-3 rounded-full bg-[#28c840]" />
+        <span className="ml-3 font-mono text-xs text-[var(--color-muted)]/50">
+          onboard-cli
+        </span>
+      </div>
+
+      {/* Terminal body */}
+      <div className="min-h-[200px] bg-[#141414] px-4 py-3 font-mono text-sm leading-relaxed">
+        {/* Command line */}
+        <div className="flex">
+          <span className="text-[#4ade80] whitespace-pre">
+            {typedCommand}
+          </span>
+          {phase !== "done" && (
+            <span className="ml-[1px] inline-block w-[7px] animate-blink bg-[#4ade80]">
+              &nbsp;
+            </span>
+          )}
+        </div>
+
+        {/* Output lines */}
+        {visibleLines.map((line, i) => (
+          <div key={i} className="mt-1">
+            <span className="text-[var(--color-foreground)]/90">
+              {line.startsWith("\u2713") ? (
+                <>
+                  <span className="text-[#4ade80]">{"\u2713"}</span>
+                  {line.slice(1)}
+                </>
+              ) : (
+                line
+              )}
+            </span>
+          </div>
+        ))}
+
+        {/* Replay indicator */}
+        {showReplay && (
+          <div className="mt-4 font-mono text-xs text-[var(--color-muted)]/30">
+            scroll away and back to replay
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/build/throughput-viz.tsx
+++ b/src/components/build/throughput-viz.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const TARGET = 47_000;
+const DURATION_MS = 2000;
+const FRAME_INTERVAL = 16;
+
+function easeOutExpo(t: number): number {
+  return t === 1 ? 1 : 1 - Math.pow(2, -10 * t);
+}
+
+function formatNumber(n: number): string {
+  return Math.round(n).toLocaleString("en-US");
+}
+
+const COBOL_LINES = [
+  "01 CUSTOMER-RECORD.",
+  '   05 CUST-ID        PIC 9(8).',
+  '   05 CUST-NAME      PIC X(30).',
+  '   05 CUST-BALANCE   PIC 9(7)V99.',
+];
+
+const JSON_LINES = [
+  "{",
+  '  "customerId": 10458923,',
+  '  "name": "MARTINEZ, ELENA",',
+  '  "balance": 15420.75',
+  "}",
+];
+
+export function ThroughputViz() {
+  const [count, setCount] = useState(0);
+  const hasAnimatedRef = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !hasAnimatedRef.current) {
+          hasAnimatedRef.current = true;
+          const start = performance.now();
+
+          function tick() {
+            const elapsed = performance.now() - start;
+            const progress = Math.min(elapsed / DURATION_MS, 1);
+            const eased = easeOutExpo(progress);
+            setCount(eased * TARGET);
+
+            if (progress < 1) {
+              setTimeout(tick, FRAME_INTERVAL);
+            } else {
+              setCount(TARGET);
+            }
+          }
+
+          tick();
+        }
+      },
+      { threshold: 0.3 },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={containerRef} className="flex flex-col items-center px-4 py-8">
+      <div className="text-center">
+        <span className="font-mono text-5xl font-bold tabular-nums tracking-tight text-[var(--color-foreground)] md:text-6xl">
+          {formatNumber(count)}
+        </span>
+        <p className="mt-2 font-mono text-sm tracking-wide text-[var(--color-muted)]">
+          translations per second
+        </p>
+      </div>
+
+      <div className="mt-8 flex w-full items-center gap-3 md:gap-6">
+        <div className="min-w-0 flex-1 overflow-hidden rounded-lg border border-white/[0.08] bg-white/[0.02] p-3 md:p-4">
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-widest text-[var(--color-muted)]/60">
+            COBOL
+          </div>
+          <pre className="overflow-x-auto font-mono text-[11px] leading-relaxed text-[var(--color-muted)] md:text-xs">
+            {COBOL_LINES.map((line, i) => (
+              <div key={i}>{line}</div>
+            ))}
+          </pre>
+        </div>
+
+        <div className="flex shrink-0 flex-col items-center gap-1">
+          <span className="font-mono text-lg text-[var(--color-accent)]">
+            &rarr;
+          </span>
+        </div>
+
+        <div className="min-w-0 flex-1 overflow-hidden rounded-lg border border-[var(--color-accent)]/15 bg-[var(--color-accent)]/[0.03] p-3 md:p-4">
+          <div className="mb-2 font-mono text-[10px] uppercase tracking-widest text-[var(--color-accent)]/60">
+            JSON
+          </div>
+          <pre className="overflow-x-auto font-mono text-[11px] leading-relaxed text-[var(--color-foreground)]/80 md:text-xs">
+            {JSON_LINES.map((line, i) => (
+              <div key={i}>{line}</div>
+            ))}
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **MCP Architecture Diagram**: React Flow with 10 custom dark-themed nodes (Open WebUI, Electron, LiteLLM, Claude/Bedrock, 6 MCP servers), animated edges, hover tooltips
- **Throughput Visualization**: Animated counter (0 → 47,000) triggered on scroll, COBOL → JSON before/after code comparison
- **Terminal CLI Demo**: Simulated macOS terminal with character-by-character typing, sequential output lines, blinking cursor, auto-replay on re-scroll
- **Lazy loading**: All three components loaded via `next/dynamic` with `ssr: false` and pulse skeleton fallbacks
- **Project card wrapper**: Framer Motion hover animation with radial gradient glow

## Layout
MCP diagram spans full width, throughput viz and terminal demo in 2-column row below.

Closes #3

## Test plan
- [ ] `pnpm build` passes
- [ ] MCP diagram renders with all nodes and hover tooltips
- [ ] Counter animates to 47,000 on scroll into view (once only)
- [ ] Terminal types command and reveals output lines
- [ ] Lazy loading verified (chunks load on scroll)
- [ ] Responsive on mobile

🤖 Generated with [Claude Code](https://claude.ai/claude-code)